### PR TITLE
Implement get remote address behind a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Sample configuration
 zuul:
   ratelimit:
     enabled: true #default false
+    behind-proxy: true #default false
     policies:
       myServiceId:
         limit: 10

--- a/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/RateLimitFilter.java
@@ -90,12 +90,22 @@ public class RateLimitFilter extends ZuulFilter {
         final Route route = route();
         StringBuilder builder = new StringBuilder(route.getId());
         if (policy.getType().contains(Policy.Type.ORIGIN)) {
-            builder.append(":").append(request.getRemoteAddr());
+            builder.append(":").append(getRemoteAddr(request));
         }
         if (policy.getType().contains(Policy.Type.USER)) {
             builder.append(":").append((request.getUserPrincipal() != null) ? request.getUserPrincipal().getName() : "anonymous");
         }
         return builder.toString();
+    }
+
+    private String getRemoteAddr(final HttpServletRequest request) {
+        final String remoteAddr;
+        if (this.properties.isBehindProxy() && request.getHeader("X-FORWARDED-FOR") != null) {
+            remoteAddr = request.getHeader("X-FORWARDED-FOR");
+        } else {
+            remoteAddr = request.getRemoteAddr();
+        }
+        return remoteAddr;
     }
 
     interface Headers {

--- a/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/config/RateLimitProperties.java
+++ b/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/config/RateLimitProperties.java
@@ -15,5 +15,5 @@ public class RateLimitProperties {
 
     private Map<String, Policy> policies = new LinkedHashMap<>();
     private boolean enabled;
-
+    private boolean behindProxy;
 }


### PR DESCRIPTION
Using getRemoteAddr behind a proxy(or a load balancer) it will get the Ip of the proxy, so to correct that this commit implements a configuration to set if application have a proxy and if it`s true check if x-forwarded-for is avaliable then use it.