### PR TITLE
Allow rate limiting per URL rather than per service

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ zuul:
         limit: 10
         refresh-interval: 60 #default value (in seconds)
         type: #optional
-          - user 
-          - origin 
+          - user
+          - origin
+          - url
 ```
 
 Footnote

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 Spring Cloud Zuul RateLimit
 ---
 Module to enable rate limit per service in Netflix Zuul.  
-There are four built-in rate limit approachs:
- - Authenticated User: *Use the authenticated username or 'anonymous'*
- - Request Origin: *Use the user origin request*
- - Authenticated User and Request Origin: *Combine the authenticated user and the Request Origin*
+There are four built-in rate limit approaches:
+ - Authenticated User: *Uses the authenticated username or 'anonymous'*
+ - Request Origin: *Uses the user origin request*
+ - URL: *Uses the request path of the upstream service*
+   - Can be combined with Authenticated User, Request Origin or both
+ - Authenticated User and Request Origin: *Combines the authenticated user and the Request Origin*
  - Global configuration per service: *This one doesn't validate the request Origin or the Authenticated User*
    - To use this approach just don't set param 'type'
-      
+
 Adding Project Lombok Agent
 ---
 

--- a/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/RateLimitFilter.java
@@ -24,6 +24,7 @@ import static com.marcosbarbero.zuul.filters.pre.ratelimit.config.Policy.Type.US
 
 /**
  * @author Marcos Barbero
+ * @author Michal Šváb
  */
 @AllArgsConstructor
 public class RateLimitFilter extends ZuulFilter {

--- a/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/RateLimitFilter.java
@@ -1,28 +1,26 @@
 package com.marcosbarbero.zuul.filters.pre.ratelimit;
 
-import static com.marcosbarbero.zuul.filters.pre.ratelimit.config.Policy.Type;
-import static com.marcosbarbero.zuul.filters.pre.ratelimit.config.Policy.Type.ORIGIN;
-import static com.marcosbarbero.zuul.filters.pre.ratelimit.config.Policy.Type.USER;
-
-import java.util.List;
-import java.util.Optional;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.springframework.cloud.netflix.zuul.filters.Route;
-import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.util.UrlPathHelper;
-
 import com.marcosbarbero.zuul.filters.pre.ratelimit.config.Policy;
 import com.marcosbarbero.zuul.filters.pre.ratelimit.config.Rate;
 import com.marcosbarbero.zuul.filters.pre.ratelimit.config.RateLimitProperties;
 import com.marcosbarbero.zuul.filters.pre.ratelimit.config.RateLimiter;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
-
 import lombok.AllArgsConstructor;
+import org.springframework.cloud.netflix.zuul.filters.Route;
+import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.util.UrlPathHelper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Optional;
+
+import static com.marcosbarbero.zuul.filters.pre.ratelimit.config.Policy.Type;
+import static com.marcosbarbero.zuul.filters.pre.ratelimit.config.Policy.Type.ORIGIN;
+import static com.marcosbarbero.zuul.filters.pre.ratelimit.config.Policy.Type.URL;
+import static com.marcosbarbero.zuul.filters.pre.ratelimit.config.Policy.Type.USER;
 
 /**
  * @author Marcos Barbero
@@ -94,6 +92,9 @@ public class RateLimitFilter extends ZuulFilter {
     private String key(final HttpServletRequest request, final List<Type> types) {
         final Route route = route();
         final StringBuilder builder = new StringBuilder(route.getId());
+        if (types.contains(URL)) {
+            builder.append(":").append(route.getPath());
+        }
         if (types.contains(ORIGIN)) {
             builder.append(":").append(getRemoteAddr(request));
         }

--- a/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/config/Policy.java
+++ b/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/config/Policy.java
@@ -5,9 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A policy is used to define rate limit constraints within RateLimiter implementations
@@ -23,7 +21,7 @@ public class Policy {
     private List<Type> type = new ArrayList<>();
 
     public enum Type {
-        ORIGIN, USER
+        ORIGIN, USER, URL
     }
 
 }

--- a/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/config/Policy.java
+++ b/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/config/Policy.java
@@ -11,6 +11,7 @@ import java.util.List;
  * A policy is used to define rate limit constraints within RateLimiter implementations
  *
  * @author Marcos Barbero
+ * @author Michal Šváb
  */
 @Data
 @NoArgsConstructor


### PR DESCRIPTION
This change allows rate limiting per path on a service. So user would get limited only if he repeatedly accessed the same path on a service, however calling various endpoints in a row wouldn't be an issue.

Feedback welcome!
Michal