### PR TITLE
Use spring-boot-starter-data-redis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-redis</artifactId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is needed asspring-boot-starter-redis has been deprecated. This is
also required in order to upgrade to spring-boot 1.5.x or later