### PR TITLE
Throw ZuulException, otherwise SendErrorFilter will return 500

### DIFF
--- a/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/marcosbarbero/zuul/filters/pre/ratelimit/RateLimitFilter.java
@@ -6,9 +6,11 @@ import com.marcosbarbero.zuul.filters.pre.ratelimit.config.RateLimitProperties;
 import com.marcosbarbero.zuul.filters.pre.ratelimit.config.RateLimiter;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
+import com.netflix.zuul.exception.ZuulException;
 
 import org.springframework.cloud.netflix.zuul.filters.Route;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
+import org.springframework.cloud.netflix.zuul.util.ZuulRuntimeException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.util.UrlPathHelper;
 
@@ -68,7 +70,7 @@ public class RateLimitFilter extends ZuulFilter {
             if (rate.getRemaining() < 0) {
                 ctx.setResponseStatusCode(HttpStatus.TOO_MANY_REQUESTS.value());
                 ctx.put("rateLimitExceeded", "true");
-                throw new RuntimeException(HttpStatus.TOO_MANY_REQUESTS.toString());
+                throw new ZuulRuntimeException(new ZuulException(HttpStatus.TOO_MANY_REQUESTS.toString(), HttpStatus.TOO_MANY_REQUESTS.value(), null));
             }
         });
         return null;


### PR DESCRIPTION
It seems that changes in `spring-cloud-netflix-core 1.3.0` have broken the rate limit filter. Now the `SendErrorFilter` expects that a `ZuulException` is thrown, otherwise it sets status 500 and ignores the value set in `ctx.setResponseStatusCode(HttpStatus.TOO_MANY_REQUESTS.value());`.

The error filter now calls following code:
```
ZuulException findZuulException(Throwable throwable) {
	if (throwable.getCause() instanceof ZuulRuntimeException) {
		// this was a failure initiated by one of the local filters
		return (ZuulException) throwable.getCause().getCause();
	}

	if (throwable.getCause() instanceof ZuulException) {
		// wrapped zuul exception
		return (ZuulException) throwable.getCause();
	}

	if (throwable instanceof ZuulException) {
		// exception thrown by zuul lifecycle
		return (ZuulException) throwable;
	}

	// fallback, should never get here
	return new ZuulException(throwable, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, null);
}
```

Cheers,
Michal